### PR TITLE
fix: Reconnect to Arcadia when connection lost.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 .hg/
 *.meta
 *.iml
+.idea

--- a/deps.edn
+++ b/deps.edn
@@ -4,5 +4,4 @@
   org.clojure/tools.cli {:mvn/version "0.4.2"}}
  :aliases
  {:repl
-  {:main-opts ["-m" "eponai.tools.cursive-arcadia-repl"]}}
- }
+  {:main-opts ["-m" "eponai.tools.cursive-arcadia-repl"]}}}

--- a/src/eponai/tools/cursive_arcadia_repl.clj
+++ b/src/eponai/tools/cursive_arcadia_repl.clj
@@ -45,20 +45,19 @@
     (if (from-cursive? code)
       (handler msg)
       ;; TODO Figure out which keys should be selected.
-      (try
-        (let [message    (select-keys msg [:id :op :code :file :file-name :file-path])
-              responses  (nrepl/message client message)
-              session-id (if (instance? clojure.lang.AReference session)
-                           (-> session meta :id)
-                           session)]
+      (let [message    (select-keys msg [:id :op :code :file :file-name :file-path])
+            responses  (nrepl/message client message)
+            session-id (if (instance? clojure.lang.AReference session)
+                         (-> session meta :id)
+                         session)]
 
-          (doseq [response responses]
-            (transport/send transport
-              (cond-> response
-                (some? session-id)
-                (assoc :session session-id)
-                (some? id)
-                (assoc :id id)))))))))
+        (doseq [response responses]
+          (transport/send transport
+            (cond-> response
+              (some? session-id)
+              (assoc :session session-id)
+              (some? id)
+              (assoc :id id))))))))
 
 
 (defn arcadia-nrepl-eval [handler msg]


### PR DESCRIPTION
Fixes #9

When running the game in Unity, the nREPL connection is lost and in order to continue send code to Unity one has to restart the bridge and the remote real in the project. 

This is fixing that by trying to reconnect when connection is lost, up to 5 retries.